### PR TITLE
Support stdin

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,8 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from contextlib import contextmanager
 from isort import SortImports
 
 import sys
+
+
+class DummyFile(object):
+    def write(self, x): pass
+
+
+@contextmanager
+def supress_stdout():
+    save_stdout = sys.stdout
+    sys.stdout = DummyFile()
+    yield
+    sys.stdout = save_stdout
 
 
 class Read(object):
@@ -35,7 +48,20 @@ class Flake8Isort(object):
     def __init__(self, tree, filename, builtins=None):
         self.content = Read.tree(tree) or Read.file(filename) or Read.stdin()
 
+    def get_line_number(self):
+        """Return the line number of the first import.
+
+        Ideally isort would give better feedback so the specific line(s)
+        could be identified. This at least will jump past any module docs.
+
+        """
+        for lno, line in enumerate(self.content.split('\n'), start=1):
+            if line.strip().startswith(('import', 'from')):
+                return lno
+        return 1
+
     def run(self):
-        sort_result = SortImports(file_contents=self.content, check=True)
+        with supress_stdout():
+            sort_result = SortImports(file_contents=self.content, check=True)
         if sort_result.incorrectly_sorted:
-            yield 0, 0, self.message, type(self)
+            yield self.get_line_number(), 0, self.message, type(self)

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,5 +1,30 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from isort import SortImports
+
+import sys
+
+
+class Read(object):
+
+    @classmethod
+    def file(cls, filename):
+        if filename == 'stdin':
+            return None
+        with open(filename, 'r') as f:
+            return f.read()
+
+    @classmethod
+    def tree(cls, tree):
+        return getattr(tree, 'source', None)
+
+    @classmethod
+    def stdin(cls):
+        content = sys.stdin.read()
+        if not content:
+            # issue: https://github.com/PyCQA/pep8/pull/443
+            print('Flake8Isort: stdin is empty')
+        return content
 
 
 class Flake8Isort(object):
@@ -7,10 +32,10 @@ class Flake8Isort(object):
     version = '0.1'
     message = 'I001 found unsorted imports'
 
-    def __init__(self, tree, filename):
-        self.filename = filename
+    def __init__(self, tree, filename, builtins=None):
+        self.content = Read.tree(tree) or Read.file(filename) or Read.stdin()
 
     def run(self):
-        sort_result = SortImports(self.filename, check=True)
+        sort_result = SortImports(file_contents=self.content, check=True)
         if sort_result.incorrectly_sorted:
             yield 0, 0, self.message, type(self)

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -18,21 +18,28 @@ def supress_stdout():
     sys.stdout = save_stdout
 
 
-class Read(object):
+class Content(object):
 
     @classmethod
-    def file(cls, filename):
+    def read(cls, tree, filename):
+        return (
+            cls.get_tree_source(tree) or
+            cls.get_file_contents(filename) or
+            cls.read_stdin())
+
+    @classmethod
+    def get_file_contents(cls, filename):
         if filename == 'stdin':
             return None
         with open(filename, 'r') as f:
             return f.read()
 
     @classmethod
-    def tree(cls, tree):
+    def get_tree_source(cls, tree):
         return getattr(tree, 'source', None)
 
     @classmethod
-    def stdin(cls):
+    def read_stdin(cls):
         content = sys.stdin.read()
         if not content:
             # issue: https://github.com/PyCQA/pep8/pull/443
@@ -46,7 +53,7 @@ class Flake8Isort(object):
     message = 'I001 found unsorted imports'
 
     def __init__(self, tree, filename, builtins=None):
-        self.content = Read.tree(tree) or Read.file(filename) or Read.stdin()
+        self.content = Content.read(tree, filename)
 
     def get_line_number(self):
         """Return the line number of the first import.

--- a/run_tests.py
+++ b/run_tests.py
@@ -45,7 +45,7 @@ class TestFlake8Isort(unittest.TestCase):
             checker = Flake8Isort(None, file_path)
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)
-            self.assertEqual(ret[0][0], 0)
+            self.assertEqual(ret[0][0], 1)
             self.assertEqual(ret[0][1], 0)
             self.assertEqual(ret[0][2], 'I001 found unsorted imports')
 


### PR DESCRIPTION
flake8-isort blew up my IDE because it did not support stdin.

To duplicate:
```
$ pip install flake8-isort
$ touch test.py
$ flake8 '-' < test.py
...
IOError: [Errno 2] No such file or directory: '/Users/doug/Projects/flake8-isort/stdin'
```

These changes ensure flake8 will not blowup.

But I noticed that flake8 checkers fail when contents are piped in:
```
$ echo "print 'hello world'" > test.py
$ flake8 '-' < test.py
Flake8Isort: stdin is empty
```

This is an issue upstream and am unsure the best way to fix.  I opened:
https://github.com/PyCQA/pep8/pull/443

Also added:
* silenced output from isort
* provided a slightly better line number
