### PR TITLE
Fix stdin handling for flake8 3+.

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+import pycodestyle
 from isort import SortImports
-from pycodestyle import stdin_get_value
+from flake8_polyfill import stdin
 from testfixtures import OutputCapture
 
 import os
@@ -10,6 +11,8 @@ try:
 except ImportError:
     from ConfigParser import ConfigParser
 
+
+stdin.monkey_patch('pycodestyle')
 
 
 class Flake8Isort(object):
@@ -48,7 +51,7 @@ class Flake8Isort(object):
             with OutputCapture():
                 if self.filename == 'stdin':
                     sort_result = SortImports(
-                        file_contents=stdin_get_value(),
+                        file_contents=pycodestyle.stdin_get_value(),
                         check=True,
                     )
                 else:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'flake8 >= 3.0.0',
+        'flake8-polyfill',
         'isort',
         'testfixtures',
     ],


### PR DESCRIPTION
Without this, flake8-isort doesn't see any data on stdin, so the stdin handling is broken.

This code is per recommendations in flake8 documentation at http://flake8.pycqa.org/en/latest/plugin-development/cross-compatibility.html#standard-in-handling-on-flake8-2-5-2-6-and-3