### PR TITLE
Add Flake8 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     # Get more from http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 3 - Alpha',
+        'Framework :: Flake8',
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         'Programming Language :: Python',


### PR DESCRIPTION
PyPI recently added "Framework :: Flake8" as a classifier
to identify Flake8 plugins and related packages. As a plugin
it makes sense for flake8-isort to start using that classifier.