### PR TITLE
Issue/edgecases

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -139,10 +139,8 @@ class Flake8Isort(object):
     def _fixup_sortimports_eof(sort_imports):
         """Ensure single end-of-file newline in `isort.SortImports.in_lines`.
 
-        isort attempts to fix EOF blank lines but Flake8 will also flag them.
-        So that these EOF changes are ignored in the diff comparison ensure
-        that SortImports `in_lines` list has just the single EOF newline to
-        match `out_lines` list.
+        isort fixes EOF blank lines but this change should be suppressed as
+        Flake8 will also flag them.
 
         Args:
             sort_imports (isort.SortImports): The isorts results object.
@@ -153,11 +151,11 @@ class Flake8Isort(object):
         """
 
         for line in reversed(sort_imports.in_lines):
-                if not line.strip():
-                    sort_imports.in_lines.pop()
-                else:
-                    sort_imports.in_lines.append('')
-                    return sort_imports
+            if not line.strip():
+                sort_imports.in_lines.pop()
+            else:
+                sort_imports.in_lines.append('')
+                break
 
     @staticmethod
     def _fixup_sortimports_wrapped(sort_imports):

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -152,7 +152,9 @@ class Flake8Isort(object):
 
         for line in reversed(sort_imports.in_lines):
             if not line.strip():
-                sort_imports.in_lines.pop()
+                # If single empty line in in_lines, do nothing.
+                if len(sort_imports.in_lines) > 1:
+                    sort_imports.in_lines.pop()
             else:
                 sort_imports.in_lines.append('')
                 break

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -115,6 +115,7 @@ class Flake8Isort(object):
 
         """
 
+        self._fixup_sortimports_wrapped(sort_result)
         self._fixup_sortimports_eof(sort_result)
 
         differ = Differ()
@@ -157,3 +158,25 @@ class Flake8Isort(object):
                 else:
                     sort_imports.in_lines.append('')
                     return sort_imports
+
+    @staticmethod
+    def _fixup_sortimports_wrapped(sort_imports):
+        """Split-up wrapped imports newlines in `SortImports.out_lines`.
+
+        isort combines wrapped lines into a single list entry string in
+        `out_lines` whereas `in_lines` are separate strings so for diff
+        comparison these need to be comparable.
+
+        Args:
+            sort_imports (isort.SortImports): The isorts results object.
+
+        Returns:
+            isort.SortImports: The modified isort results object.
+
+        """
+
+        for idx, line in enumerate(sort_imports.out_lines):
+            if '\n ' in line:
+                for new_idx, new_line in enumerate(
+                        sort_imports.out_lines.pop(idx).splitlines()):
+                    sort_imports.out_lines.insert(idx + new_idx, new_line)

--- a/run_tests.py
+++ b/run_tests.py
@@ -133,6 +133,16 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertTrue(ret[0][2].startswith('I001 '))
 
+    def test_empty_file(self):
+        file_path = self._given_a_file_in_test_dir(
+            '\n\n',
+            isort_config=''
+        )
+        with OutputCapture():
+            checker = Flake8Isort(None, file_path)
+            ret = list(checker.run())
+            self.assertEqual(ret, [])
+
     def test_wrapped_imports(self):
         file_path = self._given_a_file_in_test_dir(
             'from deluge.common import (fdate, fpcnt, fpeer, fsize, fspeed,\n'

--- a/run_tests.py
+++ b/run_tests.py
@@ -18,7 +18,7 @@ class TestFlake8Isort(unittest.TestCase):
             a_file.write(contents)
 
         with open(isort_path, 'w') as a_file:
-            a_file.write('[settings]')
+            a_file.write('[settings]\n')
             a_file.write(isort_config)
 
         return file_path

--- a/run_tests.py
+++ b/run_tests.py
@@ -133,6 +133,18 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertTrue(ret[0][2].startswith('I001 '))
 
+    def test_wrapped_imports(self):
+        file_path = self._given_a_file_in_test_dir(
+            'from deluge.common import (fdate, fpcnt, fpeer, fsize, fspeed,\n'
+            '                           ftime, get_path_size, is_infohash,\n'
+            '                           is_ip, is_magnet, is_url)\n',
+            isort_config='wrap_length=65'
+        )
+        with OutputCapture():
+            checker = Flake8Isort(None, file_path)
+            ret = list(checker.run())
+            self.assertEqual(ret, [])
+
     def test_isortcfg_found(self):
         # _given_a_file_in_test_dir already creates an .isort.cfg file
         file_path = self._given_a_file_in_test_dir(


### PR DESCRIPTION
As is always the case, you make a release then find a few more bugs ;)

These commits fix:

 - Indented wrapped imports being improperly flagged 
 - Empty files such as __init__.py being improperly flagged 
 - Fix for isort config in tests, where a mising newline meant single config settings was on same line as `[settings]` and therefore ignored.