### PR TITLE
Fix #21: AttributeError with isort skipped files

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -113,6 +113,9 @@ class Flake8Isort(object):
         Yields:
             tuple: A tuple of the specific isort line number and message.
         """
+        if sort_result.skipped:
+            raise StopIteration
+
         self._fixup_sortimports_wrapped(sort_result)
         self._fixup_sortimports_eof(sort_result)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -76,6 +76,16 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertTrue(ret[0][2].startswith('I003 '))
 
+    def test_isortcfg_skip_file(self):
+        file_path = self._given_a_file_in_test_dir(
+            'skipped_file',
+            isort_config='skip=test.py'
+        )
+        with OutputCapture():
+            checker = Flake8Isort(None, file_path)
+            ret = list(checker.run())
+            self.assertEqual(ret, [])
+
     def test_imports_unexpected_blank_line(self):
         file_path = self._given_a_file_in_test_dir(
             'from __future__ import division\n'


### PR DESCRIPTION
 - When a skipped file is passed to isort there will be no
   SortedImport.out_lines attribute but we can check for the
   `skipped` attribute and stop iteration early.