### PR TITLE
Fix #23: Invalid warnings with force_single_line enabled

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -170,7 +170,7 @@ class Flake8Isort(object):
             isort.SortImports: The modified isort results object.
         """
         for idx, line in enumerate(sort_imports.out_lines):
-            if '\n ' in line:
+            if '\n' in line:
                 for new_idx, new_line in enumerate(
                         sort_imports.out_lines.pop(idx).splitlines()):
                     sort_imports.out_lines.insert(idx + new_idx, new_line)

--- a/run_tests.py
+++ b/run_tests.py
@@ -155,6 +155,17 @@ class TestFlake8Isort(unittest.TestCase):
             ret = list(checker.run())
             self.assertEqual(ret, [])
 
+    def test_force_single_line_imports(self):
+        file_path = self._given_a_file_in_test_dir(
+            'from plone.app.testing import applyProfile\n'
+            'from plone.app.testing import FunctionalTesting\n',
+            isort_config='force_alphabetical_sort=True\nforce_single_line=True'
+        )
+        with OutputCapture():
+            checker = Flake8Isort(None, file_path)
+            ret = list(checker.run())
+            self.assertEqual(ret, [])
+
     def test_isortcfg_found(self):
         # _given_a_file_in_test_dir already creates an .isort.cfg file
         file_path = self._given_a_file_in_test_dir(


### PR DESCRIPTION
 - Similar to wrapped issue, there are newlines in the out_lines strings.
   Checking the isort code verified that only `\n` is used so it is safe
   to test for that and split up the strings.