### PR TITLE
No configuration found when is used with git hook

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -35,8 +35,9 @@ class Flake8Isort(object):
 
     config_file = None
 
-    def __init__(self, tree, filename):
+    def __init__(self, tree, filename, search_current=True):
         self.filename = filename
+        self.search_current = search_current
 
     @classmethod
     def add_options(cls, parser):
@@ -98,7 +99,29 @@ class Flake8Isort(object):
                 if 'isort' in config.sections():
                     return True
 
+        if self.search_current:
+            return self.search_isort_config_at_current()
+
         return False
+
+    def search_isort_config_at_current(self):
+        """Search for isort configuration at current directory
+        """
+        isort_file = '{0}{1}.isort.cfg'.format(os.path.realpath('.'), os.sep)
+        if os.path.exists(isort_file):
+            return True
+
+        # If the setup file exists and has an "isort" section,
+        # then we've found the configuration.
+        setup_file = '{0}{1}setup.cfg'.format(os.path.realpath('.'), os.sep)
+        if os.path.exists(setup_file):
+            config = ConfigParser()
+            config.read(setup_file)
+            if 'isort' in config.sections():
+                return True
+
+        return False
+
 
     def sortimports_linenum_msg(self, sort_result):
         """Parses isort.SortImports for line number changes and message

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -122,7 +122,6 @@ class Flake8Isort(object):
 
         return False
 
-
     def sortimports_linenum_msg(self, sort_result):
         """Parses isort.SortImports for line number changes and message
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -205,7 +205,7 @@ class TestFlake8Isort(unittest.TestCase):
         os.remove(isortcfg_path)
 
         with OutputCapture():
-            checker = Flake8Isort(None, file_path)
+            checker = Flake8Isort(None, file_path, search_current=False)
             checker.config_file = True
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)


### PR DESCRIPTION
Files with changes are moved to a temporal directory when flake8 git hook is used.

$ flake8 --install-hook git

flake8-isort should look for configuration files in the current directory while checking the files in the temporary directory.

Before fix, no configuration is found.

$ git commit -m "Commit message"
script.py:0:1: I002 no configuration found (.isort.cfg or [isort] on setup.cfg)

After fix, project configuration is found.

$ git commit -m "Commit message"
script.py:1:1: D200 One-line docstring should fit on one line with quotes