### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [zest.releaser]
 create-wheel = yes
 


### PR DESCRIPTION
As flake8-isort is a pure Python package, it is safe to distribute using universal wheels.

From http://pythonwheels.com/

> Advantages of wheels
>
> * Faster installation for pure python packages.
> * Avoids arbitrary code execution for installation. (Avoids setup.py)
> * Allows better caching for testing and continuous integration.
> * Creates .pyc files as part of installation to ensure they match the python interpreter used.
> * More consistent installs across platforms and machines.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`

Wheel documentation:

https://wheel.readthedocs.io/en/latest/

PEP 427 -- The Wheel Binary Package Format 1.0:

https://www.python.org/dev/peps/pep-0427/