### PR TITLE
Handle skipped files that aren't flagged as such

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Changelog
 
 - Nothing changed yet.
 
+2.2.2 (2017-08-19)
+------------------
+
+- Workaround for isort bug when skipping files.
+  [danpalmer]
 
 2.2.1 (2017-05-12)
 ------------------

--- a/run_tests.py
+++ b/run_tests.py
@@ -86,6 +86,19 @@ class TestFlake8Isort(unittest.TestCase):
             ret = list(checker.run())
             self.assertEqual(ret, [])
 
+    def test_file_skipped_with_comment(self):
+        # Note: files skipped in this way are not marked as
+        # "skipped" by isort <= 4.2.15, so we handle them in a
+        # different code path and test to ensure they also work.
+        file_path = self._given_a_file_in_test_dir(
+            '# isort:skip_file',
+            isort_config=''
+        )
+        with OutputCapture():
+            checker = Flake8Isort(None, file_path)
+            ret = list(checker.run())
+            self.assertEqual(ret, [])
+
     def test_imports_unexpected_blank_line(self):
         file_path = self._given_a_file_in_test_dir(
             'from __future__ import division\n'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = '{0}\n{1}'.format(
 
 setup(
     name='flake8-isort',
-    version='2.3.dev0',
+    version='2.2.2',
     description=short_description,
     long_description=long_description,
     # Get more from http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
See https://github.com/timothycrosley/isort/pull/588 for more details.

This addresses #38 until that PR is merged for isort, and to maintain backwards compatibility with older versions after it is merged.

