### PR TITLE
Minor fixes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,0 @@
-[settings]
-line_length=120
-force_single_line=True
-force_alphabetical_sort=True

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 2.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Now requires isort >= 4.3.0.
+  [jleclanche]
 
 
 2.4 (2018-02-25)

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -138,7 +138,7 @@ class Flake8Isort(object):
             tuple: A tuple of the specific isort line number and message.
         """
         if sort_result.skipped:
-            raise StopIteration
+            return
 
         self._fixup_sortimports_wrapped(sort_result)
         self._fixup_sortimports_eof(sort_result)

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -137,7 +137,7 @@ class Flake8Isort(object):
         Yields:
             tuple: A tuple of the specific isort line number and message.
         """
-        if self.should_stop_processing(sort_result):
+        if sort_result.skipped:
             raise StopIteration
 
         self._fixup_sortimports_wrapped(sort_result)
@@ -159,25 +159,6 @@ class Flake8Isort(object):
             elif line.strip() == '+':
                 # Include newline additions but do not increment line_num.
                 yield line_num + 1, self.isort_blank_req
-
-    def should_stop_processing(self, sort_result):
-        """
-        Returns whether the results should be processed.
-
-        isort marks skipped files with "skipped" in the results, but in some
-        versions fails to mark a particular class of skipped files, so these
-        are checked manually.
-
-        The bug in isort is fixed by:
-        https://github.com/timothycrosley/isort/pull/588
-        """
-        in_lines = getattr(sort_result, 'in_lines', False)
-        out_lines = getattr(sort_result, 'out_lines', False)
-
-        if not in_lines or not out_lines:
-            return True
-
-        return sort_result.skipped
 
     @staticmethod
     def _fixup_sortimports_eof(sort_imports):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'flake8 >= 3.2.1',
-        'isort',
+        'isort >= 4.3.0',
         'testfixtures',
     ],
     extras_require={


### PR DESCRIPTION
- Fixed a DeprecationWarning on Python 3.5+ (Compatible with 2.7)
- Removed the duplicate isort configuration
- Removed a workaround that is no longer required.