### PR TITLE
Adds isort output to each warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``isort_show_traceback`` option to show verbose multi-line output
+  from ``isort``, turned off by default
 
 
 2.5 (2018-03-15)

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,10 @@ This potentially avoids to lint a project that has no formal definition of how i
 With either ``--no-isort-config`` command line switch,
 or ``no-isort-config`` flake8 configuration option it can be disabled.
 
+Since version 2.6 we introduce new ``--isort-show-traceback`` option.
+It is used to show verbose multi-line output from ``isort``.
+By default it is turned off.
+
 Requirements
 ------------
 - Python 2.7, 3.5, 3.6, pypy or pypy3
@@ -39,7 +43,7 @@ Requirements
 Relation to flake8-import-order
 -------------------------------
 
-As an alternative to this flake8 plugin, there's `flake8-import-order`_ that could be worth checking out. In contrast to this plugin that defers all logic to isort, the flake8-import-order comes bundled with it's own logic. 
+As an alternative to this flake8 plugin, there's `flake8-import-order`_ that could be worth checking out. In contrast to this plugin that defers all logic to isort, the flake8-import-order comes bundled with it's own logic.
 
 flake8-import-order comes with a few predefined set of styles meanwhile this plugin can be customized a bit more. But the biggest difference could lie in that flake8-isort actually has the corresponding sorting engine isort that can sort the import orders of your existing python files. Meanwhile flake8-import-order has no such corresponding tool, hence big existing projects who want to adopt either would get a more automized experience choosing flake8-isort.
 

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -60,16 +60,19 @@ class Flake8Isort(object):
         if self.config_file and not settings_file:
             yield 0, 0, self.no_config_msg, type(self)
         else:
-            with OutputCapture():
+            with OutputCapture() as buffer:
                 sort_result = SortImports(
                     file_path=self.filename,
                     file_contents=''.join(self.lines),
                     check=True,
-                    settings_path=settings_file
+                    settings_path=settings_file,
+                    show_diff=True,
                 )
 
+            traceback = self._format_isort_output(buffer)
+
             for line_num, message in self.sortimports_linenum_msg(sort_result):
-                yield line_num, 0, message, type(self)
+                yield line_num, 0, message + traceback, type(self)
 
     def search_isort_config(self):
         # type: () -> Optional[str]
@@ -167,6 +170,23 @@ class Flake8Isort(object):
                 yield line_num + 1, self.isort_blank_req
             elif line.strip() in additions:
                 yield line_num + 1, self.isort_add_unexp
+
+    def _format_isort_output(self, isort_buffer):
+        filtering_out = ('+++', '---', '@@', 'ERROR:')
+
+        valid_lines = ['']
+        valid_lines += [
+            line
+            for line in isort_buffer.output.getvalue().splitlines()
+            if line.strip().split(' ', 1)[0] not in filtering_out
+        ]
+
+        # Normalizing newlines:
+        if len(valid_lines) > 1:
+            valid_lines.insert(1, '')
+        valid_lines.append('')
+
+        return '\n'.join(valid_lines)
 
     @staticmethod
     def _fixup_sortimports_eof(sort_imports):

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -33,6 +33,7 @@ class Flake8Isort(object):
     )
 
     config_file = None
+    show_traceback = False
 
     def __init__(self, tree, filename, lines, search_current=True):
         self.filename = filename
@@ -48,12 +49,21 @@ class Flake8Isort(object):
             help='Do not require explicit configuration to be found'
         )
 
+        parser.add_option(
+            '--isort-show-traceback',
+            action='store_true',
+            parse_from_config=True,
+            help='Show full traceback with diff from isort'
+        )
+
     @classmethod
     def parse_options(cls, options):
         if options.no_isort_config is None:
             cls.config_file = True
         else:
             cls.config_file = False
+
+        cls.show_traceback = options.isort_show_traceback
 
     def run(self):
         settings_file = self.search_isort_config()
@@ -72,7 +82,9 @@ class Flake8Isort(object):
             traceback = self._format_isort_output(buffer)
 
             for line_num, message in self.sortimports_linenum_msg(sort_result):
-                yield line_num, 0, message + traceback, type(self)
+                if self.show_traceback:
+                    message += traceback
+                yield line_num, 0, message, type(self)
 
     def search_isort_config(self):
         # type: () -> Optional[str]

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,6 +4,7 @@ from flake8_isort import Flake8Isort
 from tempfile import mkdtemp
 from testfixtures import OutputCapture
 
+import collections
 import os
 import unittest
 
@@ -267,6 +268,10 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertFalse(Flake8Isort.config_file)
 
     def test_isort_formatted_output(self):
+        options = collections.namedtuple(
+            'Options', ['no_isort_config', 'isort_show_traceback']
+        )
+
         (file_path, lines) = self._given_a_file_in_test_dir(
             'from __future__ import division\n'
             'import os\n'
@@ -278,6 +283,7 @@ class TestFlake8Isort(unittest.TestCase):
 
         with OutputCapture():
             checker = Flake8Isort(None, file_path, lines)
+            checker.parse_options(options(None, True))
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)
             self.assertEqual(ret[0][0], 2)

--- a/run_tests.py
+++ b/run_tests.py
@@ -238,11 +238,9 @@ class TestFlake8Isort(unittest.TestCase):
             checker.config_file = True
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)
-            # This was failing when the value was `0`:
-            self.assertEqual(ret[0][0], 2)
+            self.assertEqual(ret[0][0], 0)
             self.assertEqual(ret[0][1], 0)
-            # This was failing whe the value was `I002`:
-            self.assertTrue(ret[0][2].startswith('I001 '))
+            self.assertTrue(ret[0][2].startswith('I002 '))
 
     def test_default_option(self):
         """By default a config file (.isort.cfg) is expected"""


### PR DESCRIPTION
This PR introduces new warning output style.
It now includes `isort` diff with how to fix your warning.

Works the same way as `pytest-isort`.

Problem (multiple spaces):

```python
import   os
```

Old warning:

```
flake8_isort.py:7:1: I001 isort found an import in the wrong position
flake8_isort.py:7:7: E271 multiple spaces after keyword
```

New warning:

```
flake8_isort.py:7:1: I001 isort found an import in the wrong position

 from os.path import expanduser
 from testfixtures import OutputCapture
 
-import   os
+import os
 
 
 try:

flake8_isort.py:7:7: E271 multiple spaces after keyword
```

Closes #60