### PR TITLE
Fixes an issue with isort output when pipes (stdin) are uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 'pypy3'
 cache: pip
 install:
-  - pip install -e .[test]
+  - pip install .[test]
 script:
   - flake8 *.py
   - pytest run_tests.py

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -34,6 +34,7 @@ class Flake8Isort(object):
 
     config_file = None
     show_traceback = False
+    stdin_display_name = None
 
     def __init__(self, tree, filename, lines, search_current=True):
         self.filename = filename
@@ -63,6 +64,7 @@ class Flake8Isort(object):
         else:
             cls.config_file = False
 
+        cls.stdin_display_name = options.stdin_display_name
         cls.show_traceback = options.isort_show_traceback
 
     def run(self):
@@ -70,15 +72,18 @@ class Flake8Isort(object):
         if self.config_file and not settings_file:
             yield 0, 0, self.no_config_msg, type(self)
         else:
+            if self.filename is not self.stdin_display_name:
+                file_path = self.filename
+            else:
+                file_path = None
             with OutputCapture() as buffer:
                 sort_result = SortImports(
-                    file_path=self.filename,
+                    file_path=file_path,
                     file_contents=''.join(self.lines),
                     check=True,
                     settings_path=settings_file,
                     show_diff=True,
                 )
-
             traceback = self._format_isort_output(buffer)
 
             for line_num, message in self.sortimports_linenum_msg(sort_result):

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -92,7 +92,7 @@ class Flake8Isort(object):
                 yield line_num, 0, message, type(self)
 
     def search_isort_config(self):
-        # type: () -> Optional[str]
+        # type: () -> Optional[str]  # noqa: F821
         """Search for isort configuration all the way up to the root folder
 
         Looks for ``.isort.cfg``, ``.editorconfig`` or ``[isort]`` section in
@@ -118,12 +118,12 @@ class Flake8Isort(object):
         return None
 
     def search_isort_config_at_current(self):
-        # type: () -> Optional[str]
+        # type: () -> Optional[str]  # noqa: F821
         """Search for isort configuration at current directory"""
         return self._search_config_on_path(os.path.realpath('.'))
 
     def _search_config_on_path(self, path):
-        # type: (str) -> Optional[str]
+        # type: (str) -> Optional[str]  # noqa: F821
         """Search for isort configuration files at the specifed path.
 
         Args:

--- a/run_tests.py
+++ b/run_tests.py
@@ -269,7 +269,11 @@ class TestFlake8Isort(unittest.TestCase):
 
     def test_isort_formatted_output(self):
         options = collections.namedtuple(
-            'Options', ['no_isort_config', 'isort_show_traceback']
+            'Options', [
+                'no_isort_config',
+                'isort_show_traceback',
+                'stdin_display_name'
+            ]
         )
 
         (file_path, lines) = self._given_a_file_in_test_dir(
@@ -283,7 +287,7 @@ class TestFlake8Isort(unittest.TestCase):
 
         with OutputCapture():
             checker = Flake8Isort(None, file_path, lines)
-            checker.parse_options(options(None, True))
+            checker.parse_options(options(None, True, 'stdin'))
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)
             self.assertEqual(ret[0][0], 2)


### PR DESCRIPTION
This works:
```
flake8 my_file.py
my_file.py:4:1: I001 isort found an import in the wrong position
```

But this doesn't:
```
cat my_file.py | flake8 -
```

The latter is used by many editors or linter plugins (including[ SublimeLinter-flake8](https://github.com/SublimeLinter/SublimeLinter-flake8)).

This patch won't send the filename when stdin is used. It also works with a custom stdin display name:

```
cat my_file.py | flake8 --stdin-display-name=my_stdin_display_name.py -
my_stdin_display_name.py:4:1: I001 isort found an import in the wrong position
```

This works with `isort>=4.3.0` and `flake8>=3.0.0`

I also adjusted the travis config not to install this package in editable mode so the tests pass with `flake8 3.7.x`, see also https://github.com/takluyver/entrypoints/pull/30