### PR TITLE
Include .flake8 in config file search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,10 @@ Install with pip::
 
 Options
 -------
-Since version 1.0 a check for an ``.isort.cfg`` file is done,
-since version 1.1 ``setup.cfg`` is also checked for an ``[isort]`` section.
+Config options can be set in several different locations:
+* ``.isort.cfg``
+* ``.editorconfig``
+* an ``[isort]`` section in ``setup.cfg``, ``tox.ini``, or ``.flake8``
 
 This potentially avoids to lint a project that has no formal definition of how import should be sorted.
 

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -96,7 +96,7 @@ class Flake8Isort(object):
         """Search for isort configuration all the way up to the root folder
 
         Looks for ``.isort.cfg``, ``.editorconfig`` or ``[isort]`` section in
-        ``setup.cfg`` or ``tox.ini`` config files.
+        ``setup.cfg``, ``tox.ini``, or ``.flake8`` config files.
         """
         full_path = os.path.abspath(self.filename)
         split_path = (os.path.dirname(full_path), True)
@@ -138,7 +138,7 @@ class Flake8Isort(object):
                 return config_file_path
 
         # Check for '[isort]' section in other configuration files.
-        for config_file in ('tox.ini', 'setup.cfg'):
+        for config_file in ('tox.ini', 'setup.cfg', '.flake8'):
             config_file_path = os.path.join(path, config_file)
             config = SafeConfigParser()
             config.read(config_file_path)


### PR DESCRIPTION
flake8 [supports putting config options in a file called `.flake8`](http://flake8.pycqa.org/en/latest/user/configuration.html#project-configuration), so I've added that to the places to search for configuration files.

I also updated the relevant section of the README.