### PR TITLE
Fix list formatting in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Install with pip::
 Options
 -------
 Config options can be set in several different locations:
+
 * ``.isort.cfg``
 * ``.editorconfig``
 * an ``[isort]`` section in ``setup.cfg``, ``tox.ini``, or ``.flake8``


### PR DESCRIPTION
Needed a blank line before the list to make it render correctly as a bulleted list.