### PR TITLE
Increase required isort version to 4.3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'flake8 >= 3.2.1',
-        'isort[pyproject] >= 4.3.0',
+        'isort[pyproject] >= 4.3.5',
         'testfixtures',
     ],
     extras_require={


### PR DESCRIPTION
Following #71, pull #75 added the pyproject extra to the isort dependency. However, having 'isort[pyproject] >= 4.3.0' as a requirement may make installation fail, because isort versions 4.3.0 to 4.3.4 do not have the pyproject extra, as it was added in version 4.3.5. Increasing the minimum version to 4.3.5 should fix this.

----

Example of error when attempting to install flake8-isort:

pkg_resources.UnknownExtra: isort 4.3.4 has no such extra feature 'pyproject'