### PR TITLE
Let isort look up the configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,27 +19,11 @@ Install
 Install with pip::
 
     $ pip install flake8-isort
-    
+
 Install with conda::
 
     $ conda install -c conda-forge flake8-isort
 
-Options
--------
-Config options can be set in several different locations:
-
-* ``.isort.cfg``
-* ``.editorconfig``
-* an ``[isort]`` section in ``setup.cfg``, ``tox.ini``, or ``.flake8``
-
-This potentially avoids to lint a project that has no formal definition of how import should be sorted.
-
-With either ``--no-isort-config`` command line switch,
-or ``no-isort-config`` flake8 configuration option it can be disabled.
-
-Since version 2.6 we introduce new ``--isort-show-traceback`` option.
-It is used to show verbose multi-line output from ``isort``.
-By default it is turned off.
 
 Configuration
 -------------

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,16 +1,7 @@
 # -*- coding: utf-8 -*-
 from difflib import Differ
 from isort import SortImports
-from os.path import expanduser
 from testfixtures import OutputCapture
-
-import os
-
-
-try:
-    from configparser import ConfigParser as SafeConfigParser
-except ImportError:
-    from ConfigParser import SafeConfigParser
 
 
 class Flake8Isort(object):
@@ -32,7 +23,6 @@ class Flake8Isort(object):
         'I005 isort found an unexpected missing import'
     )
 
-    config_file = None
     show_traceback = False
     stdin_display_name = None
 
@@ -43,12 +33,6 @@ class Flake8Isort(object):
 
     @classmethod
     def add_options(cls, parser):
-        parser.add_option(
-            '--no-isort-config',
-            action='store_true',
-            parse_from_config=True,
-            help='Do not require explicit configuration to be found'
-        )
 
         parser.add_option(
             '--isort-show-traceback',
@@ -59,93 +43,27 @@ class Flake8Isort(object):
 
     @classmethod
     def parse_options(cls, options):
-        if options.no_isort_config is None:
-            cls.config_file = True
-        else:
-            cls.config_file = False
-
         cls.stdin_display_name = options.stdin_display_name
         cls.show_traceback = options.isort_show_traceback
 
     def run(self):
-        settings_file = self.search_isort_config()
-        if self.config_file and not settings_file:
-            yield 0, 0, self.no_config_msg, type(self)
+        if self.filename is not self.stdin_display_name:
+            file_path = self.filename
         else:
-            if self.filename is not self.stdin_display_name:
-                file_path = self.filename
-            else:
-                file_path = None
-            with OutputCapture() as buffer:
-                sort_result = SortImports(
-                    file_path=file_path,
-                    file_contents=''.join(self.lines),
-                    check=True,
-                    settings_path=settings_file,
-                    show_diff=True,
-                )
-            traceback = self._format_isort_output(buffer)
+            file_path = None
+        with OutputCapture() as buffer:
+            sort_result = SortImports(
+                file_path=file_path,
+                file_contents=''.join(self.lines),
+                check=True,
+                show_diff=True,
+            )
+        traceback = self._format_isort_output(buffer)
 
-            for line_num, message in self.sortimports_linenum_msg(sort_result):
-                if self.show_traceback:
-                    message += traceback
-                yield line_num, 0, message, type(self)
-
-    def search_isort_config(self):
-        # type: () -> Optional[str]  # noqa: F821
-        """Search for isort configuration all the way up to the root folder
-
-        Looks for ``.isort.cfg``, ``.editorconfig`` or ``[isort]`` section in
-        ``setup.cfg``, ``tox.ini``, or ``.flake8`` config files.
-        """
-        full_path = os.path.abspath(self.filename)
-        split_path = (os.path.dirname(full_path), True)
-        while split_path[1]:
-            config_on_file = self._search_config_on_path(split_path[0])
-            if config_on_file:
-                return config_on_file
-            split_path = os.path.split(split_path[0])
-
-        if self.search_current:
-            return self.search_isort_config_at_current()
-
-        # last attempt, check home folder
-        home = expanduser('~')
-        config_on_home = self._search_config_on_path(home)
-        if config_on_home:
-            return config_on_home
-
-        return None
-
-    def search_isort_config_at_current(self):
-        # type: () -> Optional[str]  # noqa: F821
-        """Search for isort configuration at current directory"""
-        return self._search_config_on_path(os.path.realpath('.'))
-
-    def _search_config_on_path(self, path):
-        # type: (str) -> Optional[str]  # noqa: F821
-        """Search for isort configuration files at the specifed path.
-
-        Args:
-            path: The path to search for config files on.
-
-        Return:
-            str: the isort config if found otherwise, None
-        """
-        for config_file in ('.isort.cfg', '.editorconfig'):
-            config_file_path = os.path.join(path, config_file)
-            if os.path.isfile(config_file_path):
-                return config_file_path
-
-        # Check for '[isort]' section in other configuration files.
-        for config_file in ('tox.ini', 'setup.cfg', '.flake8'):
-            config_file_path = os.path.join(path, config_file)
-            config = SafeConfigParser()
-            config.read(config_file_path)
-            if 'isort' in config.sections():
-                return config_file_path
-
-        return None
+        for line_num, message in self.sortimports_linenum_msg(sort_result):
+            if self.show_traceback:
+                message += traceback
+            yield line_num, 0, message, type(self)
 
     def sortimports_linenum_msg(self, sort_result):
         """Parses isort.SortImports for line number changes and message

--- a/run_tests.py
+++ b/run_tests.py
@@ -266,12 +266,25 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertIn(diff, ret[0][2])
 
-    def test_isort_uses_pyproject_toml_if_available(self):
+    def test_if_isort_cfg_is_used(self):
+        self.check_if_config_file_is_used(self.write_isort_cfg)
+
+    def test_if_setup_cfg_is_used(self):
+        self.check_if_config_file_is_used(self.write_setup_cfg)
+
+    def test_if_tox_ini_is_used(self):
+        self.check_if_config_file_is_used(self.write_tox_ini)
+
+    def test_if_pyproject_toml_is_used(self):
+        self.check_if_config_file_is_used(self.write_pyproject_toml)
+
+    def check_if_config_file_is_used(self, method_to_write_config):
         (file_path, lines) = self.write_python_file(
             'import os\n'
             'from sys import path\n',
         )
-        self.write_pyproject_toml('lines_between_types=1')
+        method_to_write_config('lines_between_types=1')
+
         with OutputCapture():
             checker = Flake8Isort(None, file_path, lines)
             ret = list(checker.run())
@@ -279,5 +292,3 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][0], 2)
             self.assertEqual(ret[0][1], 0)
             self.assertTrue(ret[0][2].startswith('I003 '))
-
-

--- a/run_tests.py
+++ b/run_tests.py
@@ -225,8 +225,7 @@ class TestFlake8Isort(unittest.TestCase):
 
     def test_isortcfg_not_found(self):
         (file_path, lines) = self._given_a_file_in_test_dir(
-            'from sys import pid\n'
-            'import threading',
+            'from sys import pid, path',
             isort_config='force_single_line=True'
         )
         # remove the .isort.cfg file
@@ -239,33 +238,9 @@ class TestFlake8Isort(unittest.TestCase):
             checker.config_file = True
             ret = list(checker.run())
             self.assertEqual(len(ret), 1)
-            self.assertEqual(ret[0][0], 0)
+            self.assertEqual(ret[0][0], 1)
             self.assertEqual(ret[0][1], 0)
-            self.assertTrue(ret[0][2].startswith('I002 '))
-
-    def test_default_option(self):
-        """By default a config file (.isort.cfg) is expected"""
-        (file_path, lines) = self._given_a_file_in_test_dir(
-            'from sys import pid\n'
-            'import threading\n',
-            isort_config='force_single_line=True'
-        )
-        with OutputCapture():
-            app = application.Application()
-            app.run([file_path, ])
-            self.assertTrue(Flake8Isort.config_file)
-
-    def test_config_file(self):
-        """Check that one can force to not look for a config file"""
-        (file_path, lines) = self._given_a_file_in_test_dir(
-            'from sys import pid\n'
-            'import threading\n',
-            isort_config='force_single_line=True'
-        )
-        with OutputCapture():
-            app = application.Application()
-            app.run(['--no-isort-config', file_path, ])
-            self.assertFalse(Flake8Isort.config_file)
+            self.assertTrue(ret[0][2].startswith('I001 '))
 
     def test_isort_formatted_output(self):
         options = collections.namedtuple(
@@ -294,7 +269,6 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertIn(diff, ret[0][2])
 
-    @unittest.expectedFailure
     def test_isort_uses_pyproject_toml_if_available(self):
         (file_path, lines) = self._given_a_file_in_test_dir(
             'import os\n'

--- a/run_tests.py
+++ b/run_tests.py
@@ -294,12 +294,17 @@ class TestFlake8Isort(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertIn(diff, ret[0][2])
 
+    @unittest.expectedFailure
     def test_isort_uses_pyproject_toml_if_available(self):
         (file_path, lines) = self._given_a_file_in_test_dir(
             'import os\n'
             'from sys import path\n',
             isort_config=''
         )
+        # remove the .isort.cfg file
+        isortcfg_path = file_path.split('/')[: -1]
+        isortcfg_path = '{0}/.isort.cfg'.format('/'.join(isortcfg_path))
+        os.remove(isortcfg_path)
 
         pyproject_toml_path = os.path.join(
             os.path.dirname(file_path), 'pyproject.toml',


### PR DESCRIPTION
When I moved my isort configuration from `setup.cfg` to `pyproject.toml` today, I noticed that there were differences between running `isort` directly and running it via `flake8`. 

Although there an effort has been made to allow isort to read TOML configuration, it still doesn't quite work with flake8-isort.

isort will look for a configuration in pyproject.toml when the TOML library is available.

flake8-isort has its own mechanism to look up an appropriate configuration file and will pass its path on to isort. Right now, flake8-isort doesn't consider `pyproject.toml` files as configuration file candidates and will raise an error if there's no other configuration file than the `pyproject.toml`.

Luckily, there's the parameter `--no-isort-config` to make flake8-isort not stall when it cannot find a config file. In this case, isort will not be instructed to look for a specific configuration file by flake8-isort but instead look for it itself (beginning from either the currently linted file path or the current working directory).

This is great because it means that we can rely on isort to figure out which config to use
and linting behavior between both libraries will be exactly the same. The search for a configuration file can be removed from flake8-isort and we get Pyproject.toml support for free.
The `--no-isort-config` option can be removed as well because from now on it will always be the burden of isort to figure out which config to use.
 