### PR TITLE
Fix version display in `flake8 --help`

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -13,9 +13,12 @@ except ImportError:
     from ConfigParser import SafeConfigParser
 
 
+__version__ = '2.8.1.dev0'
+
+
 class Flake8Isort(object):
     name = 'flake8_isort'
-    version = '2.3'
+    version = __version__
     isort_unsorted = (
         'I001 isort found an import in the wrong position'
     )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
+import re
+
+
+def get_version(file="flake8_isort.py"):
+    with open(file) as f:
+        for line in f:
+            m = re.match(r"^__version__ = '(?P<version>.*?)'$", line)
+            if m:
+                return m.group('version')
+
 
 short_description = 'flake8 plugin that integrates isort .'
 
@@ -12,7 +22,7 @@ long_description = '{0}\n{1}'.format(
 
 setup(
     name='flake8-isort',
-    version='2.8.1.dev0',
+    version=get_version(),
     description=short_description,
     long_description=long_description,
     # Get more from http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Currently, the plugin identifies itself as version 2.3 whereas we're already at 2.8.1. This pull request introduces a `__version__` module attribute which is the only thing which will need to be bumped in the future. 