### PR TITLE
Pin major version of all dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Work around `FailedToLoadPlugin` exception by requiring `isort` 4.x. Likewise,
+  pin the major version of all dependencies, to reduce risk of any future
+  incompatibilities.
+  [pkolbus]
 
 
 3.0.0 (2020-04-15)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'flake8 >= 3.2.1, <4',
-        'isort[pyproject] >= 4.3.5, <5',  # https://github.com/gforcada/flake8-isort/issues/88
+        'isort[pyproject] >= 4.3.5, <5',
         'testfixtures >= 6.8.0, <7',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'flake8 >= 3.2.1, <4',
-        'isort[pyproject] >= 4.3.5, <5',
+        'isort[pyproject] >= 4.3.5, <5',  # https://github.com/gforcada/flake8-isort/issues/88
         'testfixtures >= 6.8.0, <7',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -56,13 +56,13 @@ setup(
     test_suite='run_tests',
     zip_safe=False,
     install_requires=[
-        'flake8 >= 3.2.1',
-        'isort[pyproject] >= 4.3.5',
-        'testfixtures',
+        'flake8 >= 3.2.1, <4',
+        'isort[pyproject] >= 4.3.5, <5',
+        'testfixtures >= 6.8.0, <7',
     ],
     extras_require={
         'test': [
-            'pytest',
+            'pytest >= 4.0.2, <6',
         ],
     },
     entry_points={


### PR DESCRIPTION
Under Semantic Versioning (common for Python packages), breaking API changes can occur in a major version update. This has happened with `isort` 5 and could happen with any other package that `flake8-isort` uses.

This PR is a workaround for issue #88 to unbreak `flake8-isort` users.