### PR TITLE
Allow using flake8 v4.x.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     test_suite='run_tests',
     zip_safe=False,
     install_requires=[
-        'flake8 >= 3.2.1, <4',
+        'flake8 >= 3.2.1, <5',
         'isort >= 4.3.5, <6',
         'testfixtures >= 6.8.0, <7',
     ],


### PR DESCRIPTION
Flake8 now required python 3.6 or newer, but specifies that in its setup via 'python_requires', so hopefully those using older Python versions will automatically get an older compatible version of flake8.

Fixes #103 