### PR TITLE
Drop testfixtures dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,10 @@ jobs:
           architecture: x64
       - name: Install matrix dependencies
         run: pip install 'isort==${{ matrix.isort }}' 'flake8==${{ matrix.flake8 }}'
+      # isort 4.x requires `toml` to be able to read pyproject.toml, so install it...
+      - name: Install toml if required
+        run: pip install toml
+        if: matrix.isort == '4.3.21'
       - name: Install dependencies
         run: pip install .[test]
       - name: flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 4.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The package no longer depends on ``testfixtures``. 
 
 
 4.1.1 (2021-10-14)

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from contextlib import redirect_stdout
+from difflib import Differ
+from difflib import unified_diff
+from io import StringIO
+from pathlib import Path
+
 import isort
+import warnings
 
-
-if hasattr(isort, 'api'):  # isort 5
-    from contextlib import redirect_stdout
-    from difflib import unified_diff
-    from io import StringIO
-    from pathlib import Path
-
-    import warnings
-else:
-    from difflib import Differ
-    from testfixtures import OutputCapture
 
 __version__ = '4.1.2.dev0'
 
@@ -46,7 +42,6 @@ class Flake8IsortBase(object):
 
     @classmethod
     def add_options(cls, parser):
-
         parser.add_option(
             '--isort-show-traceback',
             action='store_true',
@@ -68,7 +63,8 @@ class Flake8Isort4(Flake8IsortBase):
             file_path = self.filename
         else:
             file_path = None
-        with OutputCapture() as buffer:
+        buffer = StringIO()
+        with redirect_stdout(buffer):
             sort_result = isort.SortImports(
                 file_path=file_path,
                 file_contents=''.join(self.lines),
@@ -129,7 +125,7 @@ class Flake8Isort4(Flake8IsortBase):
         valid_lines = ['']
         valid_lines += [
             line
-            for line in isort_buffer.output.getvalue().splitlines()
+            for line in isort_buffer.getvalue().splitlines()
             if line.strip().split(' ', 1)[0] not in filtering_out
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     install_requires=[
         'flake8 >= 3.2.1, <5',
         'isort >= 4.3.5, <6',
-        'testfixtures >= 6.8.0, <7',
     ],
     extras_require={
         'test': ['pytest-cov'],


### PR DESCRIPTION
The Python versions supported by this package all have `contextlib.redirect_stdout`, so the `testfixtures` dependency doesn't seem required.