### PR TITLE
fix parse_options bug

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -24,7 +24,7 @@ class Flake8IsortBase:
         self.filename = filename
         self.lines = lines
 
-    def add_options(option_manager):
+    def add_options(self, option_manager):
         option_manager.add_option(
             '--isort-show-traceback',
             action='store_true',


### PR DESCRIPTION
```python
TypeError: parse_options() missing 3 required positional arguments: 'option_manager', 'options', and 'args'
```

(e.g. [here](https://github.com/AMYPAD/CuVec/actions/runs/3500926406/jobs/5864067314#step:9:36))

- fixes #124
- caused by 860e7c2
  + see also https://github.com/gforcada/flake8-isort/issues/63#issuecomment-1318581190