### PR TITLE
Infer version dynamically from installed pip package

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -5,11 +5,19 @@ from io import StringIO
 from pathlib import Path
 
 import isort
+from pkg_resources import DistributionNotFound, get_distribution
+
+
+def _version():
+    try:
+        return get_distribution("flake8_isort").version
+    except DistributionNotFound:
+        return "dev"  # for local development if package is not installed yet
 
 
 class Flake8IsortBase:
     name = 'flake8_isort'
-    version = '5.0.1'
+    version = _version()
     isort_unsorted = 'I001 isort found an import in the wrong position'
     no_config_msg = 'I002 no configuration found (.isort.cfg or [isort] in configs)'
     isort_blank_req = 'I003 isort expected 1 blank line in imports, found 0'

--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -10,9 +10,9 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 def _version():
     try:
-        return get_distribution("flake8_isort").version
+        return get_distribution('flake8_isort').version
     except DistributionNotFound:
-        return "dev"  # for local development if package is not installed yet
+        return 'dev'  # for local development if package is not installed yet
 
 
 class Flake8IsortBase:


### PR DESCRIPTION
Follow up PR from #123 

This infers the version number in the flake8 plugin class automatically from the installed package version.

Also I did a quick check and think that is definitely fast enough to not be an issue:
```
> python -m timeit "from pkg_resources import get_distribution; get_distribution('flake8_isort').version"
1 loop, best of 5: 252 usec per loop
```
