### PR TITLE
Add option to allow overriding isort's skip_gitignore option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,16 @@
 Changelog
 =========
 
-5.0.4 (unreleased)
+5.1.0 (unreleased)
 ------------------
 
 - Drop isort 4.x support.
   [gforcada]
+
+- Add `--isort-no-skip-gitignore` option to allow temporarily overriding the set
+  value of isort's `skip_gitignore` option with `False`. This can cause
+  flake8-isort to run significantly faster at the cost of making flake8-isort's
+  behavior differ slightly from the behavior of `isort --check`. [gschaffner]
 
 5.0.3 (2022-11-20)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ Configuration
 -------------
 If using the `select` `option from flake8`_ be sure to enable the `I` category as well, see below for the specific error codes reported by `flake8-isort`.
 
+See ``flake8 --help`` for available flake8-isort options.
+
 Error codes
 -----------
 +------------+-----------------------------------------------------------+

--- a/run_tests.py
+++ b/run_tests.py
@@ -212,7 +212,13 @@ def test_isort_formatted_output(tmpdir):
     from sys import pid
     """
     options = collections.namedtuple(
-        'Options', ['no_isort_config', 'isort_show_traceback', 'stdin_display_name']
+        'Options',
+        [
+            'no_isort_config',
+            'isort_show_traceback',
+            'stdin_display_name',
+            'isort_no_skip_gitignore',
+        ],
     )
 
     (file_path, lines) = write_python_file(tmpdir, source)
@@ -220,7 +226,7 @@ def test_isort_formatted_output(tmpdir):
     diff = ' from __future__ import division\n+\n import os'
 
     checker = Flake8Isort(None, file_path, lines)
-    checker.parse_options(None, options(None, True, 'stdin'), None)
+    checker.parse_options(None, options(None, True, 'stdin', None), None)
     ret = list(checker.run())
     assert len(ret) == 1
     assert ret[0][0] == 3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ long_description = f"""
 
 setup(
     name='flake8-isort',
-    version='5.0.4.dev0',
+    version='5.1.0.dev0',
     description=short_description,
     long_description=long_description,
     # Get more from https://pypi.org/classifiers/


### PR DESCRIPTION
Hi!

I was profiling flake8 and found that ~90% of the runtime was just isort waiting for git subprocesses in order to implement `skip_gitignore = True`. (isort doesn't use libgit2 or anything, it just starts short-lived subprocesses targeting the git binary.)

`skip_gitignore = True` is not very useful when running flake8-isort since flake8 uses its own ignore list already. This PR adds an option `--isort-no-skip-gitignore` that allows users to force `skip_gitignore = False` when running flake8-isort without having to remove `skip_gitignore = True` from their isort config.

On the library I was profiling, `--isort-no-skip-gitignore` brought the flake8 runtime from ~50 s to ~5 s. Note that this measurement is on a Linux box. On Windows the speedup provided by this option appears to be much larger (apparently `subprocess` is extremely slow on Windows?). I actually did not finish the measurement on a Windows box because without `--isort-no-skip-gitignore`, flake8 was taking > 5 min.

Note that `skip_gitignore` was added in isort 5.2, so I added the option to `Flake8Isort5` rather than `Flake8IsortBase`.