### PR TITLE
Replace pkg_resources by importlib.metadata

### DIFF
--- a/flake8_isort.py
+++ b/flake8_isort.py
@@ -1,17 +1,17 @@
 import warnings
 from contextlib import redirect_stdout
 from difflib import unified_diff
+from importlib.metadata import PackageNotFoundError, version
 from io import StringIO
 from pathlib import Path
 
 import isort
-from pkg_resources import DistributionNotFound, get_distribution
 
 
 def _version():
     try:
-        return get_distribution('flake8_isort').version
-    except DistributionNotFound:
+        return version('flake8_isort')
+    except PackageNotFoundError:
         return 'dev'  # for local development if package is not installed yet
 
 


### PR DESCRIPTION
Hi,
Thanks for this nice module!

I'm working on a project that does not require `setuptools` and I'm getting an `ModuleNotFoundError: No module named 'pkg_resources'`.

This issue was introduced with d5f406c8756c3871d0892038179a7e2518e3b383 when the script tries to infer its version dynamically. A simple workaround is it to use `importlib.metadata` native library (for `python ≥ 3.8` and already backported in [`requirements.in`](https://github.com/gforcada/flake8-isort/blob/75e37f8002c8fc741e7a20c58df79b7a3d9a11f2/requirements.in#L3C1-L3C43) for `python 3.7`) instead of `pkg_resources`.