### PR TITLE
Add support for isort 6.0.0. Fixes: #153

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", 3.9, 3.8, pypy-3.9]
+        python-version: ["3.13", "3.12", "3.11", "3.10", 3.9, pypy-3.9]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -36,7 +36,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v3.14.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -46,6 +46,6 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.21.3"
+    rev: "0.22.1"
     hooks:
     -   id: check-python-versions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ Changelog
 6.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for isort 6.0.0.
+  [SukiCZ]
+
+- Drop python 3.8, and add python 3.13.
+  [SukiCZ]
 
 
 6.1.1 (2023-11-03)

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Error codes
 
 Requirements
 ------------
-- Python 3.8, 3.9, 3.10, 3.11 and pypy3
+- Python 3.9, 3.10, 3.11, 3.12, 3.13 and pypy3
 - flake8
 - isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "flake8 plugin that integrates isort"
 keywords = ["pep8", "flake8", "python", "isort", "imports"]
 license = {file = "LICENSE"}
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -24,17 +24,17 @@ classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development",
         "Topic :: Software Development :: Quality Assurance",
 ]
-dependencies = ["flake8", "isort >= 5.0.0, <6"]
+dependencies = ["flake8", "isort >= 5.0.0, <7"]
 
 [project.urls]
 "Homepage" = "https://github.com/gforcada/flake8-isort"
@@ -51,7 +51,7 @@ I00 = "flake8_isort:Flake8Isort"
 profile = "plone"
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 skip-string-normalization = true
 
 [tool.check-manifest]

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist =
     format
     lint
     coverage
-    py38
     py39
     py310
     py311
     py312
+    py313
     pypy3
 
 [testenv:test]


### PR DESCRIPTION
Add support for isort 6.0.0. Fixes: #153

* Drop python 3.8, and add python 3.13.